### PR TITLE
Improve spanish locale config automatic translation from english

### DIFF
--- a/lessons/locales_config/es.yml
+++ b/lessons/locales_config/es.yml
@@ -27,32 +27,31 @@ es:
       fr: "Francés"
       es: "Español"
   home:
-    tagline: 
-      title: "Si usted quisiera ver esto en su idioma local. Por favor ayúdenos a traducir."
+    tagline:
+      title: "Si quieres ver esto en tu idioma local. Por favor ayúdanos a traducir."
     subscribe:
       title: "Suscribir"
-      body: "Obtener actualizaciones sobre nuevos cursos y lecciones!"
+      body: "¡Obtener actualizaciones sobre nuevos cursos y lecciones!"
     about:
       title: "Sobre nosotros"
-      body: "El conocimiento adquirido aquí hoy fue impulsado por la comunidad de código abierto."
+      body: "El conocimiento adquirido aquí fue impulsado por la comunidad de código abierto."
       url_name: "Contribuir y colaborar"
       url: "https://github.com/cindyq/linuxjourney"
     contact:
       title: "Contáctenos"
-      body: "Ver un error? Cualquier queja? Sólo quiero enviar una nota?"
+      body: "¿Ves un error? ¿Alguna queja? ¿Quieres enviar sólo una nota?"
       url_name: "Haznos saber"
       url: "contact@linuxjourney.com"
   courses:
     titles:
-      exercises: "Ceremonias"
+      exercises: "Ejercicios"
       quiz: "Examen"
   forms:
     buttons:
-      check_answer: "Checar respuesta"
+      check_answer: "Revisar respuesta"
       continue: "Continuar"
       return: "Volver al Menú Principal"
-      home: "página de inicio"
+      home: "Página de inicio"
     messages:
       answer_correct: "¡Respuesta correcta!"
-      answer_incorrect: "No del todo, inténtelo de nuevo"
-      
+      answer_incorrect: "No es correcto, inténtalo de nuevo"


### PR DESCRIPTION
There were some things that the automated translation didn't get fully right.
I also removed the `usted` third-person formality for a more friendly/informal `tú`.

I have already translated some sections to spanish. Should I push them directly as markdowns just like the english ones? Or will you include a way to automate that as YAMLs, just like this one, to keep the examples the same across all languages?

Wonderful initiative by the way!