### PR TITLE
[Upd] Update apt defenition to version 1.x

### DIFF
--- a/lessons/locales/en_english/packages/package-management-systems.md
+++ b/lessons/locales/en_english/packages/package-management-systems.md
@@ -7,14 +7,14 @@ Ah, the Batmans of package management, these systems come with all the fixins to
 <b>Install a package from a repository</b>
 
 <pre>
-Debian: $ apt-get install package_name
+Debian: $ apt install package_name
 RPM: $ yum install package_name
 </pre>
 
 <b>Remove a package</b>
 
 <pre>
-Debian: $ apt-get remove package_name
+Debian: $ apt remove package_name
 RPM: $ yum erase package_name
 </pre>
 
@@ -23,14 +23,14 @@ RPM: $ yum erase package_name
 It's always best practice to update your package repositories so they are up to date before you install and update a package. 
 
 <pre>
-Debian: apt-get update; apt-get upgrade
+Debian: apt update; apt upgrade
 RPM: yum update
 </pre>
 
 <b>Get information about an installed package</b>
 
 <pre>
-Debian: apt-cache show package_name
+Debian: apt show package_name
 RPM: yum info package_name
 </pre>
 
@@ -44,4 +44,4 @@ What command is used to show package information on a Debian system?
 
 ## Quiz Answer
 
-apt-cache show
+apt show


### PR DESCRIPTION
Since 1.x version of apt utility this is standalone, so no need for apt-* sub-commands.
It's now easier to use & remember. Faster to type.